### PR TITLE
LineageActions: Proximity check should respect global preference

### DIFF
--- a/LineageActions/src/org/lineageos/settings/device/FPGestureSettingsFragment.java
+++ b/LineageActions/src/org/lineageos/settings/device/FPGestureSettingsFragment.java
@@ -38,10 +38,13 @@ import org.lineageos.settings.device.actions.Constants;
 import static org.lineageos.settings.device.actions.Constants.FP_HOME_KEY;
 import static org.lineageos.settings.device.actions.Constants.FP_HOME_KEY_OFF;
 
+import org.lineageos.settings.device.utils.ProximityUtils;
+
 public class FPGestureSettingsFragment extends PreferenceFragment {
 
     private SwitchPreference mFPScreenOffGesture;
     private PreferenceCategory mFPScreenOffCategory;
+    private SwitchPreference mFPScreenOffProxCheck;
     private PreferenceCategory mFPScreenOnCategory;
 
     private TextView mSwitchBarText;
@@ -83,11 +86,11 @@ public class FPGestureSettingsFragment extends PreferenceFragment {
         mSwitchBarText.setText(isFPGestureEnabled() ? R.string.switch_bar_on :
                 R.string.switch_bar_off);
     }
-    
+
     private void updatePrefs(boolean enabled){
         Editor prefEditor = PreferenceManager.getDefaultSharedPreferences(getActivity()).edit();
         prefEditor.putBoolean(FP_HOME_KEY, enabled);
-        prefEditor.apply(); 
+        prefEditor.apply();
         mFPScreenOnCategory.setEnabled(enabled);
         mFPScreenOffGesture.setEnabled(enabled);
         mFPScreenOffCategory.setEnabled(enabled);
@@ -96,8 +99,11 @@ public class FPGestureSettingsFragment extends PreferenceFragment {
             mFPScreenOffGesture.setEnabled(!hasEnrolledFingerprints);
             mFPScreenOffCategory.setEnabled(!hasEnrolledFingerprints);
         }
+        if (mFPScreenOffCategory.isEnabled()){
+          mFPScreenOffProxCheck.setEnabled(ProximityUtils.isProximityWakeEnabled(getActivity()));
+        }
     }
-    
+
     private boolean isFPGestureEnabled(){
         return Constants.isPreferenceEnabled(getActivity(), FP_HOME_KEY);
     }
@@ -107,6 +113,7 @@ public class FPGestureSettingsFragment extends PreferenceFragment {
         addPreferencesFromResource(R.xml.fp_gesture_panel);
         mFPScreenOffGesture = (SwitchPreference) findPreference(FP_HOME_KEY_OFF);
         mFPScreenOffCategory = (PreferenceCategory) findPreference("fp_keys_scr_off");
+        mFPScreenOffProxCheck = (SwitchPreference) mFPScreenOffCategory.findPreference("fp_proximity_check_scr_off");
         mFPScreenOnCategory = (PreferenceCategory) findPreference("fp_keys_scr_on");
         updatePrefs(isFPGestureEnabled());
     }

--- a/LineageActions/src/org/lineageos/settings/device/KeyHandler.java
+++ b/LineageActions/src/org/lineageos/settings/device/KeyHandler.java
@@ -67,9 +67,9 @@ import org.lineageos.settings.device.util.FileUtils;
 
 import java.util.List;
 
-import lineageos.providers.LineageSettings;
-
 import static org.lineageos.settings.device.actions.Constants.*;
+
+import org.lineageos.settings.device.utils.ProximityUtils;
 
 public class KeyHandler implements DeviceKeyHandler {
 
@@ -101,7 +101,6 @@ public class KeyHandler implements DeviceKeyHandler {
     private Sensor mProximitySensor;
     private Vibrator mVibrator;
     private int mProximityTimeOut;
-    private boolean mProximityWakeSupported;
     private ISearchManager mSearchManagerService;
     private Handler mHandler;
     private int fpTapCounts = 0;
@@ -149,13 +148,10 @@ public class KeyHandler implements DeviceKeyHandler {
         mGestureWakeLock = mPowerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,
                 "GestureWakeLock");
 
-        final Resources resources = mContext.getResources();
-        mProximityTimeOut = resources.getInteger(
+        mProximityTimeOut = mContext.getResources().getInteger(
                 org.lineageos.platform.internal.R.integer.config_proximityCheckTimeout);
-        mProximityWakeSupported = resources.getBoolean(
-                org.lineageos.platform.internal.R.bool.config_proximityCheckOnWake);
 
-        if (mProximityWakeSupported) {
+        if (ProximityUtils.isProximityWakeEnabled(mContext)) {
             mSensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
             mProximitySensor = mSensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
             mProximityWakeLock = mPowerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,
@@ -445,11 +441,11 @@ public class KeyHandler implements DeviceKeyHandler {
     }
 
     private boolean isProximityEnabledOnScreenOffGesturesFP() {
-        return !FileUtils.readOneLine(getFPNodeBasedOnScreenState(FP_PROXIMITY_CHECK_SCREENOFF_NODE)).equals("0");
+        return ProximityUtils.isProximityWakeEnabled(mContext) && !FileUtils.readOneLine(getFPNodeBasedOnScreenState(FP_PROXIMITY_CHECK_SCREENOFF_NODE)).equals("0");
     }
 
     private boolean isProximityEnabledOnScreenOffGestures() {
-        return Settings.System.getInt(mContext.getContentResolver(), KEY_GESTURE_ENABLE_PROXIMITY_SENSOR, 1) != 0;
+        return ProximityUtils.isProximityWakeEnabled(mContext) && Settings.System.getInt(mContext.getContentResolver(), KEY_GESTURE_ENABLE_PROXIMITY_SENSOR, 1) != 0;
     }
 
     private String getFPNodeBasedOnScreenState(String node) {
@@ -702,16 +698,8 @@ public class KeyHandler implements DeviceKeyHandler {
         if (isProximityEnabledOnScreenOffGesturesFP() && !mFPScreenOffGesturesHandler.hasMessages(FP_ACTION_REQUEST)) {
             Message msg = mFPScreenOffGesturesHandler.obtainMessage(FP_ACTION_REQUEST);
             msg.arg1 = scanCode;
-            boolean defaultProximity = mContext.getResources().getBoolean(
-                    org.lineageos.platform.internal.R.bool.config_proximityCheckOnWakeEnabledByDefault);
-            boolean proximityWakeCheckEnabled = LineageSettings.System.getInt(mContext.getContentResolver(),
-                    LineageSettings.System.PROXIMITY_ON_WAKE, defaultProximity ? 1 : 0) == 1;
-            if (mProximityWakeSupported && proximityWakeCheckEnabled && mProximitySensor != null) {
-                mFPScreenOffGesturesHandler.sendMessageDelayed(msg, mProximityTimeOut);
-                registerFPScreenOffListener(scanCode);
-            } else {
-                mFPScreenOffGesturesHandler.sendMessage(msg);
-            }
+            mFPScreenOffGesturesHandler.sendMessageDelayed(msg, mProximityTimeOut);
+            registerFPScreenOffListener(scanCode);
         }else{
             processFPScancode(scanCode);
         }
@@ -765,16 +753,8 @@ public class KeyHandler implements DeviceKeyHandler {
         if (isProximityEnabledOnScreenOffGestures() && !mScreenOffGesturesHandler.hasMessages(GESTURE_REQUEST)) {
             Message msg = mScreenOffGesturesHandler.obtainMessage(GESTURE_REQUEST);
             msg.arg1 = scanCode;
-            boolean defaultProximity = mContext.getResources().getBoolean(
-                    org.lineageos.platform.internal.R.bool.config_proximityCheckOnWakeEnabledByDefault);
-            boolean proximityWakeCheckEnabled = LineageSettings.System.getInt(mContext.getContentResolver(),
-                    LineageSettings.System.PROXIMITY_ON_WAKE, defaultProximity ? 1 : 0) == 1;
-            if (mProximityWakeSupported && proximityWakeCheckEnabled && mProximitySensor != null) {
-                mScreenOffGesturesHandler.sendMessageDelayed(msg, mProximityTimeOut);
-                registerScreenOffGesturesListener(scanCode);
-            } else {
-                mScreenOffGesturesHandler.sendMessage(msg);
-            }
+            mScreenOffGesturesHandler.sendMessageDelayed(msg, mProximityTimeOut);
+            registerScreenOffGesturesListener(scanCode);
         }else{
             processScreenOffScancode(scanCode);
         }

--- a/LineageActions/src/org/lineageos/settings/device/ScreenOffGestureSettingsFragment.java
+++ b/LineageActions/src/org/lineageos/settings/device/ScreenOffGestureSettingsFragment.java
@@ -27,6 +27,8 @@ import static android.provider.Settings.Secure.DOUBLE_TAP_TO_WAKE;
 import static org.lineageos.settings.device.actions.Constants.KEY_GESTURE_ENABLE_HAPTIC_FEEDBACK;
 import static org.lineageos.settings.device.actions.Constants.KEY_GESTURE_ENABLE_PROXIMITY_SENSOR;
 
+import org.lineageos.settings.device.utils.ProximityUtils;
+
 public class ScreenOffGestureSettingsFragment extends PreferenceFragment {
 
     private SwitchPreference mTapToWake;
@@ -74,6 +76,7 @@ public class ScreenOffGestureSettingsFragment extends PreferenceFragment {
                 return true;
             }
         });
+        mProximitySensor.setEnabled(ProximityUtils.isProximityWakeEnabled(getActivity()));
     }
 
 }

--- a/LineageActions/src/org/lineageos/settings/device/util/ProximityUtils.java
+++ b/LineageActions/src/org/lineageos/settings/device/util/ProximityUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016 The CyanogenMod Project
+ * Copyright (C) 2017 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lineageos.settings.device.utils;
+
+import android.content.Context;
+import lineageos.providers.LineageSettings;
+
+public class ProximityUtils {
+    public static boolean isProximityWakeEnabled(Context context){
+        boolean mProximityWakeSupported = context.getResources().getBoolean(
+                org.lineageos.platform.internal.R.bool.config_proximityCheckOnWake);
+        boolean defaultProximity = context.getResources().getBoolean(
+                org.lineageos.platform.internal.R.bool.config_proximityCheckOnWakeEnabledByDefault);
+        boolean proximityWakeCheckEnabled = LineageSettings.System.getInt(context.getContentResolver(),
+               LineageSettings.System.PROXIMITY_ON_WAKE, defaultProximity ? 1 : 0) == 1;
+        return mProximityWakeSupported && proximityWakeCheckEnabled;
+    }
+}


### PR DESCRIPTION
The parent preference is located on Settings > Display > Prevent accidental wake-up

Also cleanup repeated code

Signed-off-by: Henrique Silva <jhenrique09.mcz@hotmail.com>